### PR TITLE
Shared implementation for Ptr and ByteArray# hashing

### DIFF
--- a/cbits/hashByteString.c
+++ b/cbits/hashByteString.c
@@ -7,3 +7,10 @@ long djb_hash(const unsigned char* str, long len, long hash) {
 
   return hash;
 }
+
+/* Used for ByteArray#s. We can't treat them like pointers in
+   native Haskell, but we can in unsafe FFI calls.
+ */
+long djb_hash_offset(const unsigned char* str, long offset, long len, long hash) {
+  return djb_hash(str + offset, len, hash);
+}


### PR DESCRIPTION
Tests are passing - I'm not sure how I was running them wrong last time.
This adds the UnliftedFFITypes extension flag, which seems to have been added in GHC 6.8. I haven't looked into this too much - let me know if you want to try and support GHC 6.6.

Timings for my laptop:

hashByteArray/5
34.5ns -> 21.3ns

hashByteArray/8
49.2ns -> 26.7ns

hashByteArray/11
63.6ns -> 31.3ns

hashByteArray/40
207.7ns -> 83.4ns

hashByteArray/2^20
5.15ms -> 1.85ms
