### PR TITLE
Fix and test for 64-bit hashing on 32-bit machines

### DIFF
--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -98,9 +98,8 @@ instance Hashable Int16 where hash = fromIntegral
 instance Hashable Int32 where hash = fromIntegral
 instance Hashable Int64 where
     hash n
-        | bitSize n == 64 = fromIntegral n
-        | otherwise = fromIntegral (fromIntegral n `xor`
-                                   (fromIntegral n `shiftR` 32 :: Word64))
+        | bitSize (0::Int) == 64 = fromIntegral n
+        | otherwise = fromIntegral n `combine` fromIntegral (n `shiftR` 32)
 
 instance Hashable Word where hash = fromIntegral
 instance Hashable Word8 where hash = fromIntegral
@@ -108,8 +107,8 @@ instance Hashable Word16 where hash = fromIntegral
 instance Hashable Word32 where hash = fromIntegral
 instance Hashable Word64 where
     hash n
-        | bitSize n == 64 = fromIntegral n
-        | otherwise = fromIntegral (n `xor` (n `shiftR` 32))
+        | bitSize (0::Int) == 64 = fromIntegral n
+        | otherwise = fromIntegral n `combine` fromIntegral (n `shiftR` 32)
 
 instance Hashable Char where hash = fromEnum
 

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,5 +1,5 @@
 Name:                hashable
-Version:             1.1.0.0
+Version:             1.1.0.1
 Synopsis:            A class for types that can be converted to a hash value
 Description:         This package defines a class, 'Hashable', for types that
                      can be converted to a hash value.  This class


### PR DESCRIPTION
I noticed that the test for 32-bit Int in Hashable.hs was subtly wrong (it tested the 64-bit incoming argument rather than the width of Int), and thus we were discarding high-order bits for 64-bit quantities.  I fixed this and wrote a test, only to realize that the hash function was rather poor for values centered around 0.  As a consequence I substituted "combine" for "xor" in the hash computation.  This isn't great (combine itself isn't fantastic as it leads to 2-character hash collisions among other unpleasantness), but it at least solves the most trivial problems.
