### PR TITLE
Added a default generic instance for Hashable

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,5 +1,5 @@
 Name:                hashable
-Version:             1.1.2.5
+Version:             1.2.0.0
 Synopsis:            A class for types that can be converted to a hash value
 Description:         This package defines a class, 'Hashable', for types that
                      can be converted to a hash value.  This class


### PR DESCRIPTION
This change merges the hashable-generics package into hashable.

Note that this removes the default non-generic implementation for hashWithSalt. This means the minimal default implementation changes from "hash or hashWithSalt" to "hashWithSalt or Generic".

Because of that, this change required a major version bump.
