### PR TITLE
Fix #41 (I hope)

### DIFF
--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -78,10 +78,12 @@ main = do
         fnvHash (PS fp off len) =
             inlinePerformIO . withForeignPtr fp $ \ptr ->
             return $! fnv_hash (ptr `plusPtr` off) (fromIntegral len) 2166136261
-#ifdef HAVE_SSE
+#ifdef HAVE_SSE2
         sse2SipHash (PS fp off len) =
             inlinePerformIO . withForeignPtr fp $ \ptr ->
             return $! sse2_siphash k0 k1 (ptr `plusPtr` off) (fromIntegral len)
+#endif
+#ifdef HAVE_SSE41
         sse41SipHash (PS fp off len) =
             inlinePerformIO . withForeignPtr fp $ \ptr ->
             return $! sse41_siphash k0 k1 (ptr `plusPtr` off) (fromIntegral len)
@@ -201,7 +203,7 @@ main = do
           , bench "512" $ whnf cSipHash24 bs512
           , bench "2^20" $ whnf cSipHash24 bs1Mb
           ]
-#ifdef HAVE_SSE
+#ifdef HAVE_SSE2
         , bgroup "sse2SipHash"
           [ bench "5" $ whnf sse2SipHash bs5
           , bench "8" $ whnf sse2SipHash bs8
@@ -211,6 +213,8 @@ main = do
           , bench "512" $ whnf sse2SipHash bs512
           , bench "2^20" $ whnf sse2SipHash bs1Mb
           ]
+#endif
+#ifdef HAVE_SSE41
         , bgroup "sse41SipHash"
           [ bench "5" $ whnf sse41SipHash bs5
           , bench "8" $ whnf sse41SipHash bs8
@@ -261,9 +265,11 @@ foreign import ccall unsafe "hashable_siphash" c_siphash
     :: CInt -> CInt -> Word64 -> Word64 -> Ptr Word8 -> CSize -> Word64
 foreign import ccall unsafe "hashable_siphash24" c_siphash24
     :: Word64 -> Word64 -> Ptr Word8 -> CSize -> Word64
-#ifdef HAVE_SSE
+#ifdef HAVE_SSE2
 foreign import ccall unsafe "hashable_siphash24_sse2" sse2_siphash
     :: Word64 -> Word64 -> Ptr Word8 -> CSize -> Word64
+#endif
+#ifdef HAVE_SSE41
 foreign import ccall unsafe "hashable_siphash24_sse41" sse41_siphash
     :: Word64 -> Word64 -> Ptr Word8 -> CSize -> Word64
 #endif

--- a/cbits/siphash.c
+++ b/cbits/siphash.c
@@ -109,8 +109,10 @@ static void maybe_use_sse()
 
     if (edx & (1 << 26))
 	_siphash24 = hashable_siphash24_sse2;
+#if defined(HAVE_SSE41)
     else if (ecx & (1 << 19))
 	_siphash24 = hashable_siphash24_sse41;
+#endif
     else
 	_siphash24 = plain_siphash24;
 }

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -31,6 +31,10 @@ Flag fixed-salt
   Description: Do we use a single fixed salt every time the program runs?
   Default: False
 
+Flag sse41
+  Description: Do we want to assume that a target supports SSE 4.1?
+  Default: False
+
 Library
   Exposed-modules:   Data.Hashable
   Other-modules:     Data.Hashable.Class
@@ -53,8 +57,12 @@ Library
                      cbits/siphash.c
   if arch(i386)
     C-sources:       cbits/siphash-sse2.c
-                     cbits/siphash-sse41.c
-    CC-options:      -msse2 -msse4.1
+    CC-options:      -msse2
+
+    if flag(sse41)
+      CPP-Options:   -DHAVE_SSE41
+      CC-options:    -msse41
+      C-sources:     cbits/siphash-sse41.c
 
   Ghc-options:       -Wall
   if impl(ghc >= 6.8)
@@ -117,11 +125,16 @@ benchmark benchmarks
     benchmarks/cbits/inthash.c
 
   if arch(i386) || arch(x86_64)
-    cpp-options: -DHAVE_SSE
-    cc-options: -msse2 -msse4.1
+    cpp-options: -DHAVE_SSE2
+    cc-options: -msse2
     c-sources:
       cbits/siphash-sse2.c
-      cbits/siphash-sse41.c
+
+    if flag(sse41)
+      cpp-options: -DHAVE_SSE41
+      cc-options: -msse4.1
+      c-sources:
+        cbits/siphash-sse41.c
 
   Ghc-options:       -Wall -O2
   if impl(ghc >= 6.8)


### PR DESCRIPTION
Since we can't use specific compiler options for individual source files without performing major build surgery (and possibly not even then), I've simply turned off SSE4.1 by default.
