### PR TITLE
Use per-file pragmas instead of enabling -msse* globally.

### DIFF
--- a/cbits/siphash-sse2.c
+++ b/cbits/siphash-sse2.c
@@ -4,6 +4,8 @@
  *
  * Used with permission.
  */
+#pragma GCC target("sse2")
+
 #include <emmintrin.h>
 #include "siphash.h"
 

--- a/cbits/siphash-sse41.c
+++ b/cbits/siphash-sse41.c
@@ -4,6 +4,8 @@
  *
  * Used with permission.
  */
+#pragma GCC target("sse4.1")
+
 #include <smmintrin.h>
 #include "siphash.h"
 

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -57,11 +57,9 @@ Library
                      cbits/siphash.c
   if arch(i386)
     C-sources:       cbits/siphash-sse2.c
-    CC-options:      -msse2
 
     if flag(sse41)
       CPP-Options:   -DHAVE_SSE41
-      CC-options:    -msse41
       C-sources:     cbits/siphash-sse41.c
 
   Ghc-options:       -Wall
@@ -126,13 +124,11 @@ benchmark benchmarks
 
   if arch(i386) || arch(x86_64)
     cpp-options: -DHAVE_SSE2
-    cc-options: -msse2
     c-sources:
       cbits/siphash-sse2.c
 
     if flag(sse41)
       cpp-options: -DHAVE_SSE41
-      cc-options: -msse4.1
       c-sources:
         cbits/siphash-sse41.c
 


### PR DESCRIPTION
Fixes #50.
