### PR TITLE
Rescuing platforms which don't have le64toh.

### DIFF
--- a/cbits/siphash.c
+++ b/cbits/siphash.c
@@ -3,9 +3,23 @@
 #include <stddef.h>
 #include "siphash.h"
 
-#ifndef _WIN32
-# include <endian.h>
-#else
+#if defined(OS_MacOS)
+#  include <libkern/OSByteOrder.h>
+#  define le64toh(x) OSSwapLittleToHostInt64(x)
+#elif defined(DOS_BSD)
+#  include <sys/endian.h>
+#elif defined(DOS_Linux)
+#  include <endian.h>
+#  ifndef le64toh
+#    if __BYTE_ORDER == __LITTLE_ENDIAN
+#      define le64toh(x) (x)
+#    else
+#      define le64toh(x) __bswap_64 (x)
+#    endif
+#  endif
+#endif
+
+#ifndef le64toh
 # define le64toh
 #endif
 

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -71,6 +71,15 @@ Library
     if os(windows)
       extra-libraries: advapi32
 
+  if os(freebsd) || os(netbsd) || os(openbsd)
+    CPP-Options:        -DOS_BSD
+  else
+    if os(darwin)
+      CPP-Options:      -DOS_MacOS
+    else
+      if os(linux)
+        CPP-Options:    -DOS_Linux
+
 Test-suite tests
   Type:              exitcode-stdio-1.0
   Hs-source-dirs:    tests


### PR DESCRIPTION
This patch make hashable compilable on MacOS/BSD/32bit Linux without using configure. I have tested this on:
- MacOS (Mountain Lion)
- 32bit Linux
- 64bit Linux
- FreeBS
