### PR TITLE
Add support for `Data.ByteString.Short`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version TBA
+
+ * Add instances for `Data.ByteString.Short`
+
 ## Version 1.2.1.0
 
  * Revert instances to their 1.1 implementations to regain the

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -83,6 +83,10 @@ import Foreign.C.Types (CInt)
 import qualified Data.ByteString.Lazy.Internal as BL  -- foldlChunks
 #endif
 
+#if MIN_VERSION_bytestring(0,10,4)
+import qualified Data.ByteString.Short.Internal as BSI
+#endif
+
 #ifdef VERSION_integer_gmp
 import GHC.Exts (Int(..))
 import GHC.Integer.GMP.Internals (Integer(..))
@@ -368,6 +372,16 @@ instance Hashable B.ByteString where
 
 instance Hashable BL.ByteString where
     hashWithSalt = BL.foldlChunks hashWithSalt
+
+#if MIN_VERSION_bytestring(0,10,4)
+instance Hashable BSI.ShortByteString where
+#if MIN_VERSION_base(4,3,0)
+    hashWithSalt salt sbs@(BSI.SBS ba) =
+#else
+    hashWithSalt salt sbs@(BSI.SBS ba _) =
+#endif
+        hashByteArrayWithSalt ba 0 (BSI.length sbs) salt
+#endif
 
 instance Hashable T.Text where
     hashWithSalt salt (T.Text arr off len) =


### PR DESCRIPTION
The short bytestring has been added with bytestring-0.10.4 (as shipped with
GHC 7.8.x). Due to internal changes in the ByteArray# representation, the
ShortByteString value constructor has an additional field with base<4.3
(i.e. GHC <7.0), this has been taken care of by CPP checks.

A simple property-check has been added to the testsuite in order to exercise
some of the new code-paths.

NB: This requires at least a minor version bump

This addresses tibbe/hashable#79
