### PR TITLE
Use new 'typeRepHash' field accessor for GHC>=7.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,37 +2,38 @@
 
 # The following enables several GHC versions to be tested; often it's enough to test only against the last release in a major GHC version. Feel free to omit lines listings versions you don't need/want testing for.
 env:
- - GHCVER=7.4.2
- - GHCVER=7.6.3
- - GHCVER=7.8.1
+ - CABALVER=1.18 GHCVER=7.4.2
+ - CABALVER=1.18 GHCVER=7.6.3
+ - CABALVER=1.18 GHCVER=7.8.4
+ - CABALVER=1.22 GHCVER=7.10.1
 # - GHCVER=head  # see section about GHC HEAD snapshots
 
 # Note: the distinction between `before_install` and `install` is not important.
 before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc
  - sudo apt-get update
- - sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
- - export PATH=/opt/ghc/$GHCVER/bin:$PATH
+ - sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER happy
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 
 # Benchmarks aren't built as installing their dependencies causes a
 # dependency cycle.
 install:
- - cabal-1.18 update
- - cabal-1.18 install --only-dependencies --enable-tests
+ - cabal update
+ - cabal install --only-dependencies --enable-tests
 
 # Here starts the actual work to be performed for the package under test; any command which exits with a non-zero exit code causes the build to fail.
 script:
- - cabal-1.18 configure --enable-tests -v2  # -v2 provides useful information for debugging
- - cabal-1.18 build   # this builds all libraries and executables (including tests/benchmarks)
- - cabal-1.18 test
- - cabal-1.18 check
- - cabal-1.18 sdist   # tests that a source-distribution can be generated
+ - cabal configure --enable-tests -v2  # -v2 provides useful information for debugging
+ - cabal build   # this builds all libraries and executables (including tests/benchmarks)
+ - cabal test
+ - cabal check
+ - cabal sdist   # tests that a source-distribution can be generated
 
 # The following scriptlet checks that the resulting source distribution can be built & installed
- - export SRC_TGZ=$(cabal-1.18 info . | awk '{print $2 ".tar.gz";exit}') ;
+ - export SRC_TGZ=$(cabal info . | awk '{print $2 ".tar.gz";exit}') ;
    cd dist/;
    if [ -f "$SRC_TGZ" ]; then
-      cabal-1.18 install "$SRC_TGZ";
+      cabal install "$SRC_TGZ";
    else
       echo "expected '$SRC_TGZ' not found";
       exit 1;

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -66,7 +66,9 @@ import System.Mem.StableName
 import GHC.Generics
 #endif
 
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 710
+import GHC.Fingerprint.Type(Fingerprint(..))
+#elif __GLASGOW_HASKELL__ >= 702
 import Data.Typeable.Internal(TypeRep(..))
 import GHC.Fingerprint.Type(Fingerprint(..))
 #endif
@@ -451,7 +453,10 @@ instance Hashable ThreadId where
 -- | Compute the hash of a TypeRep, in various GHC versions we can do this quickly.
 hashTypeRep :: TypeRep -> Int
 {-# INLINE hashTypeRep #-}
-#if __GLASGOW_HASKELL__ >= 702
+#if __GLASGOW_HASKELL__ >= 710
+-- Fingerprint is just the MD5, so taking any Int from it is fine
+hashTypeRep tr = let Fingerprint x _ = typeRepHash tr in fromIntegral x
+#elif __GLASGOW_HASKELL__ >= 702
 -- Fingerprint is just the MD5, so taking any Int from it is fine
 hashTypeRep (TypeRep (Fingerprint x _) _ _) = fromIntegral x
 #elif __GLASGOW_HASKELL__ >= 606


### PR DESCRIPTION
This is available starting with GHC 7.10.0.20150307 (see
ghc/ghc@b2b1c8d4623db6f8fe38afbe59a8adcf0815056d) and avoids having to
import the unsafe `Data.Typeable.Internal` module while providing some
level of forward compatibility regarding changes to the internal
representation of `TypeRep`.

NB: This will break compilation with the exisiting GHC 7.10.1 RC1 and
    RC2 snapshots