### PR TITLE
Call mmap through a C helper

### DIFF
--- a/cbits/mmap.c
+++ b/cbits/mmap.c
@@ -1,0 +1,40 @@
+/*
+Copyright Colin Watson 2015
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+    * Neither the name of Colin Watson nor the names of other
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sys/mman.h>
+
+void *hashable_mmap(void *addr, size_t length, int prot, int flags,
+		    int fd, off_t offset)
+{
+  return mmap(addr, length, prot, flags, fd, offset);
+}

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -82,6 +82,7 @@ Test-suite tests
   if !os(windows)
     Build-depends:   unix
     CPP-options:     -DHAVE_MMAP
+    C-sources:       cbits/mmap.c
     Other-modules:   Regress.Mmap
 
   Ghc-options:       -Wall -fno-warn-orphans

--- a/tests/Regress/Mmap.hsc
+++ b/tests/Regress/Mmap.hsc
@@ -60,7 +60,7 @@ mprotect :: Ptr a -> CSize -> CInt -> IO ()
 mprotect addr len prot =
     throwErrnoIfMinus1_ "mprotect" $ c_mprotect addr len prot
 
-foreign import ccall unsafe "sys/mman.h mmap"
+foreign import ccall unsafe "hashable_mmap"
     c_mmap :: Ptr a -> CSize -> CInt -> CInt -> CInt -> COff -> IO (Ptr a)
 
 foreign import ccall unsafe "sys/mman.h munmap"


### PR DESCRIPTION
This fixes problems with the type of the offset argument on some
architectures, and makes it possible to build with e.g.
-D_FILE_OFFSET_BITS=64 (hsc2hs doesn't handle the conditional tricks in
<sys/mman.h> very well).

Fixes #95.
