### PR TITLE
List with length

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,15 @@ script:
    else
       echo "expected '$SRC_TGZ' not found";
       exit 1;
+   fi;
+   cd ../
+
+ # Try to compile tests and benchmarks, run tests
+ # For some reason doesn't work with old cabal
+ - if [ ! $CABALVER = "1.16" ]; then
+     cabal install HUnit QuickCheck criterion random siphash test-framework test-framework-hunit test-framework-quickcheck2;
+     cabal configure -v2 --enable-tests --enable-benchmarks;
+     cabal test;
    fi
 
 # EOF

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -430,9 +430,15 @@ instance Hashable (StableName a) where
     hash = hashStableName
     hashWithSalt = defaultHashWithSalt
 
+-- Auxillary type for Hashable [a] definition
+data SPInt = SP !Int !Int
+
 instance Hashable a => Hashable [a] where
     {-# SPECIALIZE instance Hashable [Char] #-}
-    hashWithSalt = foldl' hashWithSalt
+    hashWithSalt salt arr = finalise (foldl' step (SP salt 0) arr)
+      where
+        finalise (SP s l) = hashWithSalt s l
+        step (SP s l) x   = SP (hashWithSalt s x) (l + 1)
 
 instance Hashable B.ByteString where
     hashWithSalt salt bs = B.inlinePerformIO $

--- a/benchmarks/Benchmarks.hs
+++ b/benchmarks/Benchmarks.hs
@@ -98,13 +98,13 @@ main = do
         withForeignPtr fp1Mb $ \ p1Mb ->
         defaultMain
         [ bgroup "hashPtr"
-          [ bench "5" $ hashPtr p5 5
-          , bench "8" $ hashPtr p8 8
-          , bench "11" $ hashPtr p11 11
-          , bench "40" $ hashPtr p40 40
-          , bench "128" $ hashPtr p128 128
-          , bench "512" $ hashPtr p512 512
-          , bench "2^20" $ hashPtr p1Mb mb
+          [ bench "5" $ whnfIO $ hashPtr p5 5
+          , bench "8" $ whnfIO $ hashPtr p8 8
+          , bench "11" $ whnfIO $ hashPtr p11 11
+          , bench "40" $ whnfIO $ hashPtr p40 40
+          , bench "128" $ whnfIO $ hashPtr p128 128
+          , bench "512" $ whnfIO $ hashPtr p512 512
+          , bench "2^20" $ whnfIO $ hashPtr p1Mb mb
           ]
         , bgroup "hashByteArray"
           [ bench "5" $ whnf (hashByteArray ba5 0) 5

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -104,7 +104,7 @@ benchmark benchmarks
   build-depends:
     base,
     bytestring,
-    criterion,
+    criterion >= 1.0,
     ghc-prim,
     siphash,
     text


### PR DESCRIPTION
Based on https://github.com/tibbe/hashable/pull/102, I did some local benchmarks; for some reason this version is ~ half of time for every `hash/String` benchmark (i.e. faster).

Related to https://github.com/tibbe/hashable/issues/74

I could add `hashWithSalt len` to tuple instances too, so `((a, b), c)` and `(a,b,c)` will have different hashes.