### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/benchmarks/cbits/siphash.h
+++ b/benchmarks/cbits/siphash.h
@@ -2,6 +2,7 @@
 #define _hashable_siphash_h
 
 #include <stdint.h>
+#include <stdlib.h>
 
 typedef uint64_t u64;
 typedef uint32_t u32;

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -20,7 +20,8 @@ Cabal-version:       >=1.8
 -- tests/Properties.hs shouldn't have to go here, but the source files
 -- for the test-suite stanzas don't get picked up by `cabal sdist`.
 Extra-source-files:
-  CHANGES.md, README.md, tests/Properties.hs, benchmarks/Benchmarks.hs
+  CHANGES.md, README.md, tests/Properties.hs,
+  benchmarks/Benchmarks.hs, benchmarks/cbits/*.c, benchmarks/cbits/*.h
 
 Flag integer-gmp
   Description: Are we using integer-gmp to provide fast Integer instances?

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -115,6 +115,12 @@ benchmark benchmarks
   if impl(ghc) && flag(integer-gmp)
     Build-depends:   integer-gmp >= 0.2
 
+  include-dirs:
+    benchmarks/cbits
+
+  includes:
+    siphash.h
+
   c-sources:
     benchmarks/cbits/inthash.c
     benchmarks/cbits/siphash.c


### PR DESCRIPTION
Currently, the benchmarks fail to compile when obtained from Hackage since a header file (`siphash.h`) is not bundled in the tarball via `cabal sdist`. This PR explicitly adds it to `hashable.cabal`.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065