### PR TITLE
Higher kinded classes

### DIFF
--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -242,7 +242,7 @@ instance Ord a => Ord (Hashed a) where
 instance Show a => Show (Hashed a) where
   showsPrec d (Hashed a _) = showsUnaryWith showsPrec "hashed" d a
 
-instance Hashable a => Hashable (Hashed a) where
+instance Hashable (Hashed a) where
   hashWithSalt = defaultHashWithSalt
   hash (Hashed _ h) = h
 

--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -235,6 +235,12 @@ instance Hashable a => Hashable (Hashed a) where
   hashWithSalt = defaultHashWithSalt
   hash (Hashed _ h) = h
 
+-- This instance is a little unsettling. It is unusal for
+-- 'liftHashWithSalt' to ignore its first argument when a
+-- value is actually available for it to work on.
+instance Hashable1 Hashed where
+  liftHashWithSalt _ s (Hashed _ h) = defaultHashWithSalt s h
+
 instance (IsString a, Hashable a) => IsString (Hashed a) where
   fromString s = let r = fromString s in Hashed r (hash r)
 

--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -72,8 +72,12 @@ module Data.Hashable
 
 import Data.String (IsString(..))
 import Data.Typeable (Typeable)
-import Data.Foldable (Foldable(foldr))
 import Data.Hashable.Class
+
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (Foldable(foldr))
+#endif
+
 #ifdef GENERICS
 import Data.Hashable.Generic ()
 #endif

--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -79,7 +79,7 @@ import Data.Foldable (Foldable(foldr))
 #endif
 
 #if MIN_VERSION_base(4,9,0)
-import Data.Functor.Classes (Eq1(..),Ord1(..),Show1(..))
+import Data.Functor.Classes (Eq1(..),Ord1(..),Show1(..),showsUnaryWith)
 #endif
 
 #ifdef GENERICS
@@ -240,7 +240,8 @@ instance Ord a => Ord (Hashed a) where
   Hashed a _ `compare` Hashed b _ = a `compare` b
 
 instance Show a => Show (Hashed a) where
-  showsPrec d (Hashed a _) = showsUnaryWith showsPrec "hashed" d a
+  showsPrec d (Hashed a _) = showParen (d > 10) $
+    showString "hashed" . showChar ' ' . showsPrec 11 a
 
 instance Hashable (Hashed a) where
   hashWithSalt = defaultHashWithSalt
@@ -270,11 +271,4 @@ instance Ord1 Hashed where
 instance Show1 Hashed where
   liftShowsPrec sp _ d (Hashed a _) = showsUnaryWith sp "hashed" d a
 #endif
-
--- This function is copied from Data.Functor.Classes, which does
--- not export it.
-showsUnaryWith :: (Int -> a -> ShowS) -> String -> Int -> a -> ShowS
-showsUnaryWith sp name d x = showParen (d > 10) $
-    showString name . showChar ' ' . sp 11 x
-
 

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -30,7 +30,7 @@ module Data.Hashable.Class
 #ifdef GENERICS
       -- ** Support for generics
     , GHashable(..)
-    , ToHash(..)
+    , HashArgs(..)
     , Zero
     , One
 #endif
@@ -199,18 +199,18 @@ class Hashable a where
 
 #ifdef GENERICS
     default hashWithSalt :: (Generic a, GHashable Zero (Rep a)) => Int -> a -> Int
-    hashWithSalt salt = ghashWithSalt ToHash0 salt . from
+    hashWithSalt salt = ghashWithSalt HashArgs0 salt . from
 
 data Zero = Zero
 data One = One
 
-data ToHash arity a where
-    ToHash0 :: ToHash Zero a
-    ToHash1 :: (Int -> a -> Int) -> ToHash One a
+data HashArgs arity a where
+    HashArgs0 :: HashArgs Zero a
+    HashArgs1 :: (Int -> a -> Int) -> HashArgs One a
 
 -- | The class of types that can be generically hashed.
 class GHashable arity f where
-    ghashWithSalt :: ToHash arity a -> Int -> f a -> Int
+    ghashWithSalt :: HashArgs arity a -> Int -> f a -> Int
 
 #endif
 
@@ -219,7 +219,7 @@ class Hashable1 t where
     liftHashWithSalt :: (Int -> a -> Int) -> Int -> t a -> Int
 #ifdef GENERICS
     default liftHashWithSalt :: (Generic1 t, GHashable One (Rep1 t)) => (Int -> a -> Int) -> Int -> t a -> Int
-    liftHashWithSalt h salt = ghashWithSalt (ToHash1 h) salt . from1
+    liftHashWithSalt h salt = ghashWithSalt (HashArgs1 h) salt . from1
 #endif
 
 class Hashable2 t where

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -46,6 +46,10 @@ module Data.Hashable.Class
     , hashWithSalt1
     , hashWithSalt2
     , defaultLiftHashWithSalt
+    -- * Caching hashes
+    , Hashed
+    , hashed
+    , unhashed
     ) where
 
 import Control.Applicative (Const(..))
@@ -148,11 +152,14 @@ import GHC.Exts (Word(..))
 #if MIN_VERSION_base(4,9,0)
 import qualified Data.List.NonEmpty as NE
 import Data.Semigroup
+import Data.Functor.Classes (Eq1(..),Ord1(..),Show1(..),showsUnaryWith)
 
 import Data.Functor.Compose (Compose(..))
 import qualified Data.Functor.Product as FP
 import qualified Data.Functor.Sum as FS
 #endif
+
+import Data.String (IsString(..))
 
 #include "MachDeps.h"
 
@@ -797,6 +804,58 @@ instance (Hashable1 f, Hashable1 g) => Hashable1 (FS.Sum f g) where
 
 instance (Hashable1 f, Hashable1 g, Hashable a) => Hashable (FS.Sum f g a) where
     hashWithSalt = hashWithSalt1
+#endif
+
+-- | A hashable value along with the result of the 'hash' function.
+data Hashed a = Hashed a {-# UNPACK #-} !Int
+  deriving (Typeable)
+
+-- | Wrap a hashable value, caching the 'hash' function result.
+hashed :: Hashable a => a -> Hashed a
+hashed a = Hashed a (hash a)
+
+-- | Unwrap hashed value.
+unhashed :: Hashed a -> a
+unhashed (Hashed a _) = a
+
+-- | Uses precomputed hash to detect inequality faster
+instance Eq a => Eq (Hashed a) where
+  Hashed a ha == Hashed b hb = ha == hb && a == b
+
+instance Ord a => Ord (Hashed a) where
+  Hashed a _ `compare` Hashed b _ = a `compare` b
+
+instance Show a => Show (Hashed a) where
+  showsPrec d (Hashed a _) = showParen (d > 10) $
+    showString "hashed" . showChar ' ' . showsPrec 11 a
+
+instance Hashable (Hashed a) where
+  hashWithSalt = defaultHashWithSalt
+  hash (Hashed _ h) = h
+
+-- This instance is a little unsettling. It is unusal for
+-- 'liftHashWithSalt' to ignore its first argument when a
+-- value is actually available for it to work on.
+instance Hashable1 Hashed where
+  liftHashWithSalt _ s (Hashed _ h) = defaultHashWithSalt s h
+
+instance (IsString a, Hashable a) => IsString (Hashed a) where
+  fromString s = let r = fromString s in Hashed r (hash r)
+
+instance Foldable Hashed where
+  foldr f acc (Hashed a _) = f a acc
+
+-- instances for @Data.Functor.Classes@ higher rank typeclasses
+-- in base-4.9 and onward.
+#if MIN_VERSION_base(4,9,0)
+instance Eq1 Hashed where
+  liftEq f (Hashed a ha) (Hashed b hb) = ha == hb && f a b
+
+instance Ord1 Hashed where
+  liftCompare f (Hashed a _) (Hashed b _) = f a b
+
+instance Show1 Hashed where
+  liftShowsPrec sp _ d (Hashed a _) = showsUnaryWith sp "hashed" d a
 #endif
 
 

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -471,37 +471,73 @@ instance Hashable2 Either where
 
 instance (Hashable a1, Hashable a2) => Hashable (a1, a2) where
     hash (a1, a2) = hash a1 `hashWithSalt` a2
-    hashWithSalt s (a1, a2) = s `hashWithSalt` a1 `hashWithSalt` a2
+    hashWithSalt = hashWithSalt1
+
+instance Hashable a1 => Hashable1 ((,) a1) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance Hashable2 (,) where
+    liftHashWithSalt2 h1 h2 s (a1, a2) = s `h1` a1 `h2` a2
 
 instance (Hashable a1, Hashable a2, Hashable a3) => Hashable (a1, a2, a3) where
     hash (a1, a2, a3) = hash a1 `hashWithSalt` a2 `hashWithSalt` a3
-    hashWithSalt s (a1, a2, a3) = s `hashWithSalt` a1 `hashWithSalt` a2
-                        `hashWithSalt` a3
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable a1, Hashable a2) => Hashable1 ((,,) a1 a2) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance Hashable a1 => Hashable2 ((,,) a1) where
+    liftHashWithSalt2 h1 h2 s (a1, a2, a3) =
+      (s `hashWithSalt` a1) `h1` a2 `h2` a3
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4) =>
          Hashable (a1, a2, a3, a4) where
     hash (a1, a2, a3, a4) = hash a1 `hashWithSalt` a2
                             `hashWithSalt` a3 `hashWithSalt` a4
-    hashWithSalt s (a1, a2, a3, a4) = s `hashWithSalt` a1 `hashWithSalt` a2
-                            `hashWithSalt` a3 `hashWithSalt` a4
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable a1, Hashable a2, Hashable a3) => Hashable1 ((,,,) a1 a2 a3) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance (Hashable a1, Hashable a2) => Hashable2 ((,,,) a1 a2) where
+    liftHashWithSalt2 h1 h2 s (a1, a2, a3, a4) =
+      (s `hashWithSalt` a1 `hashWithSalt` a2) `h1` a3 `h2` a4
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5)
       => Hashable (a1, a2, a3, a4, a5) where
     hash (a1, a2, a3, a4, a5) =
         hash a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5
-    hashWithSalt s (a1, a2, a3, a4, a5) =
-        s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
-        `hashWithSalt` a4 `hashWithSalt` a5
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable a1, Hashable a2, Hashable a3,
+          Hashable a4) => Hashable1 ((,,,,) a1 a2 a3 a4) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance (Hashable a1, Hashable a2, Hashable a3)
+      => Hashable2 ((,,,,) a1 a2 a3) where
+    liftHashWithSalt2 h1 h2 s (a1, a2, a3, a4, a5) =
+      (s `hashWithSalt` a1 `hashWithSalt` a2
+         `hashWithSalt` a3) `h1` a4 `h2` a5
+
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5,
           Hashable a6) => Hashable (a1, a2, a3, a4, a5, a6) where
     hash (a1, a2, a3, a4, a5, a6) =
         hash a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6
-    hashWithSalt s (a1, a2, a3, a4, a5, a6) =
-        s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
-        `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4,
+          Hashable a5) => Hashable1 ((,,,,,) a1 a2 a3 a4 a5) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance (Hashable a1, Hashable a2, Hashable a3,
+          Hashable a4) => Hashable2 ((,,,,,) a1 a2 a3 a4) where
+    liftHashWithSalt2 h1 h2 s (a1, a2, a3, a4, a5, a6) =
+      (s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
+         `hashWithSalt` a4) `h1` a5 `h2` a6
+
 
 instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5,
           Hashable a6, Hashable a7) =>
@@ -512,6 +548,15 @@ instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5,
     hashWithSalt s (a1, a2, a3, a4, a5, a6, a7) =
         s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
         `hashWithSalt` a4 `hashWithSalt` a5 `hashWithSalt` a6 `hashWithSalt` a7
+
+instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4, Hashable a5, Hashable a6) => Hashable1 ((,,,,,,) a1 a2 a3 a4 a5 a6) where
+    liftHashWithSalt = defaultLiftHashWithSalt
+
+instance (Hashable a1, Hashable a2, Hashable a3, Hashable a4,
+          Hashable a5) => Hashable2 ((,,,,,,) a1 a2 a3 a4 a5) where
+    liftHashWithSalt2 h1 h2 s (a1, a2, a3, a4, a5, a6, a7) =
+      (s `hashWithSalt` a1 `hashWithSalt` a2 `hashWithSalt` a3
+         `hashWithSalt` a4 `hashWithSalt` a5) `h1` a6 `h2` a7
 
 instance Hashable (StableName a) where
     hash = hashStableName

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -731,17 +731,23 @@ instance Hashable a => Hashable (Option a) where
 -- | In general, @hash (Compose x) ≠ hash x@. However, @hashWithSalt@ satisfies
 -- its variant of this equivalence.
 instance (Hashable1 f, Hashable1 g, Hashable a) => Hashable (Compose f g a) where
-    hashWithSalt s (Compose v) = liftHashWithSalt (liftHashWithSalt hashWithSalt) s v
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable1 f, Hashable1 g) => Hashable1 (Compose f g) where
+    liftHashWithSalt h s = liftHashWithSalt (liftHashWithSalt h) s . getCompose
+
+instance (Hashable1 f, Hashable1 g) => Hashable1 (FP.Product f g) where
+    liftHashWithSalt h s (FP.Pair a b) = liftHashWithSalt h (liftHashWithSalt h s a) b
 
 instance (Hashable1 f, Hashable1 g, Hashable a) => Hashable (FP.Product f g a) where
-    hashWithSalt s (FP.Pair a b) = liftHashWithSalt
-      hashWithSalt
-      (liftHashWithSalt hashWithSalt s a)
-      b
+    hashWithSalt = hashWithSalt1
+
+instance (Hashable1 f, Hashable1 g) => Hashable1 (FS.Sum f g) where
+    liftHashWithSalt h s (FS.InL a) = liftHashWithSalt h (s `combine` 0) a
+    liftHashWithSalt h s (FS.InR a) = liftHashWithSalt h (s `combine` distinguisher) a
 
 instance (Hashable1 f, Hashable1 g, Hashable a) => Hashable (FS.Sum f g a) where
-    hashWithSalt s (FS.InL a) = liftHashWithSalt hashWithSalt (s `combine` 0) a
-    hashWithSalt s (FS.InR a) = liftHashWithSalt hashWithSalt (s `combine` distinguisher) a
+    hashWithSalt = hashWithSalt1
 #endif
 
 

--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -2,7 +2,7 @@
              ScopedTypeVariables, UnliftedFFITypes #-}
 #ifdef GENERICS
 {-# LANGUAGE DefaultSignatures, FlexibleContexts, GADTs,
-    MultiParamTypeClasses #-}
+    MultiParamTypeClasses, EmptyDataDecls #-}
 #endif
 
 ------------------------------------------------------------------------
@@ -75,6 +75,10 @@ import GHC.Prim (ThreadId#)
 import System.IO.Unsafe (unsafePerformIO)
 import System.Mem.StableName
 import Data.Unique (Unique, hashUnique)
+
+#if !(MIN_VERSION_base(4,7,0))
+import Data.Proxy (Proxy)
+#endif
 
 #if MIN_VERSION_base(4,7,0)
 import Data.Fixed (Fixed(..))
@@ -205,8 +209,8 @@ class Hashable a where
     default hashWithSalt :: (Generic a, GHashable Zero (Rep a)) => Int -> a -> Int
     hashWithSalt salt = ghashWithSalt HashArgs0 salt . from
 
-data Zero = Zero
-data One = One
+data Zero
+data One
 
 data HashArgs arity a where
     HashArgs0 :: HashArgs Zero a

--- a/Data/Hashable/Generic.hs
+++ b/Data/Hashable/Generic.hs
@@ -69,7 +69,8 @@ instance (GSum arity a, GSum arity b) => GSum arity (a :+: b) where
     {-# INLINE hashSum #-}
 
 instance GHashable arity a => GSum arity (C1 c a) where
-    hashSum toHash !salt !code _ (M1 x) = ghashWithSalt toHash (hashWithSalt salt code) x
+    -- hashSum toHash !salt !code _ (M1 x) = ghashWithSalt toHash (hashWithSalt salt code) x
+    hashSum toHash !salt !code _ (M1 x) = hashWithSalt salt (ghashWithSalt toHash code x)
     {-# INLINE hashSum #-}
 
 class SumSize f where

--- a/Data/Hashable/Generic.hs
+++ b/Data/Hashable/Generic.hs
@@ -44,13 +44,13 @@ instance Hashable a => GHashable arity (K1 i a) where
     ghashWithSalt _ = hashUsing unK1
 
 instance GHashable One Par1 where
-    ghashWithSalt (ToHash1 h) salt = h salt . unPar1
+    ghashWithSalt (HashArgs1 h) salt = h salt . unPar1
 
 instance Hashable1 f => GHashable One (Rec1 f) where
-    ghashWithSalt (ToHash1 h) salt = liftHashWithSalt h salt . unRec1
+    ghashWithSalt (HashArgs1 h) salt = liftHashWithSalt h salt . unRec1
 
 class GSum arity f where
-    hashSum :: ToHash arity a -> Int -> Int -> Int -> f a -> Int
+    hashSum :: HashArgs arity a -> Int -> Int -> Int -> f a -> Int
 
 instance (GSum arity a, GSum arity b, SumSize a, SumSize b) => GHashable arity (a :+: b) where
     ghashWithSalt toHash salt = hashSum toHash salt 0 size
@@ -70,7 +70,7 @@ instance GHashable arity a => GSum arity (C1 c a) where
     {-# INLINE hashSum #-}
 
 instance GSum One Par1 where
-    hashSum (ToHash1 h) !salt !code _ (Par1 x) =
+    hashSum (HashArgs1 h) !salt !code _ (Par1 x) =
       h (hashWithSalt salt code) x
     {-# INLINE hashSum #-}
 

--- a/Data/Hashable/Lifted.hs
+++ b/Data/Hashable/Lifted.hs
@@ -1,0 +1,96 @@
+------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Hashable.Class
+-- Copyright   :  (c) Milan Straka 2010
+--                (c) Johan Tibell 2011
+--                (c) Bryan O'Sullivan 2011, 2012
+-- License     :  BSD-style
+-- Maintainer  :  johan.tibell@gmail.com
+-- Stability   :  provisional
+-- Portability :  portable
+--
+-- Lifting of the 'Hashable' class to unary and binary type constructors.
+-- These classes are needed to express the constraints on arguments of
+-- types that are parameterized by type constructors. Fixed-point data
+-- types and monad transformers are such types.
+
+module Data.Hashable.Lifted
+    ( -- * Type Classes
+      Hashable1(..)
+    , Hashable2(..)
+      -- * Auxiliary Functions
+    , hashWithSalt1
+    , hashWithSalt2
+    , defaultLiftHashWithSalt
+      -- * Motivation
+      -- $motivation
+    ) where
+
+import Data.Hashable.Class
+
+-- $motivation
+--
+-- This type classes provided in this module are used to express constraints
+-- on type constructors in a Haskell98-compatible fashion. As an example, consider
+-- the following two types (Note that these instances are not actually provided
+-- because @hashable@ does not have @transformers@ or @free@ as a dependency):
+--
+-- > newtype WriterT w m a = WriterT { runWriterT :: m (a, w) }
+-- > data Free f a = Pure a | Free (f (Free f a))
+--
+-- The 'Hashable1' instances for @WriterT@ and @Free@ could be written as:
+--
+-- > instance (Hashable w, Hashable1 m) => Hashable1 (WriterT w m) where
+-- >     liftHashWithSalt h s (WriterT m) =
+-- >         liftHashWithSalt (liftHashWithSalt2 h hashWithSalt) s m
+-- > instance (Hashable1 f, Functor f) => Hashable1 (Free f) where
+-- >     liftHashWithSalt h = go where
+-- >         go s x = case x of
+-- >             Pure a -> h s a
+-- >             Free p -> liftHashWithSalt go p
+--
+-- The 'Hashable' instances for these types can be trivially recovered with
+-- 'hashWithSalt1':
+--
+-- > instance (Hashable w, Hashable1 m, Hashable a) => Hashable (WriterT w m a) where
+-- >     hashWithSalt = hashWithSalt1
+-- > instance (Hashable1 f, Hashable a) => Hashable1 (Free f a) where
+-- >     hashWithSalt = hashWithSalt1
+
+--
+-- $discussion
+--
+-- Regardless of whether 'hashWithSalt1' is used to provide an implementation
+-- of 'hashWithSalt', they should produce the same hash when called with
+-- the same arguments. This is the only law that 'Hashable1' and 'Hashable2'
+-- are expected to follow.
+--
+-- The typeclasses in this module only provide lifting for 'hashWithSalt', not
+-- for 'hash'. This is because such liftings cannot be defined in a way that
+-- would satisfy the @liftHash@ variant of the above law. As an illustration
+-- of the problem we run into, let us assume that 'Hashable1' were
+-- given a 'liftHash' method:
+--
+-- > class Hashable1 t where
+-- >     liftHash :: (Int -> a) -> t a -> Int
+-- >     liftHashWithSalt :: (Int -> a -> Int) -> Int -> t a -> Int
+--
+-- Even for a type as simple as 'Maybe', the problem manifests itself. The
+-- 'Hashable' instance for 'Maybe' is:
+--
+-- > distinguisher :: Int
+-- > distinguisher = ...
+-- >
+-- > instance Hashable a => Hashable (Maybe a) where
+-- >     hash Nothing = 0
+-- >     hash (Just a) = distinguisher `hashWithSalt` a
+-- >     hashWithSalt s Nothing = ...
+-- >     hashWithSalt s (Just a) = ...
+--
+-- The implementation of 'hash' calls 'hashWithSalt' on @a@. The hypothetical
+-- @liftHash@ defined earlier only accepts an argument that corresponds to
+-- the implementation of 'hash' for @a@. Consequently, this formulation of
+-- @liftHash@ would not provide a way to match the current behavior of 'hash'
+-- for 'Maybe'. This problem gets worse when 'Either' and @[]@ are considered.
+-- The solution adopted in this library is to omit @liftHash@ entirely.
+

--- a/examples/Main.hs
+++ b/examples/Main.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE DeriveGeneric #-}
+import Data.Hashable
+import GHC.Generics (Generic)
+
+data Foo
+  = Foo1 Int Char Bool
+  | Foo2 String ()
+  deriving (Generic)
+
+instance Hashable Foo
+
+data Bar = Bar Double Float
+  deriving (Generic)
+
+instance Hashable Bar
+
+-- printHash :: (Hashable a, Show a) => a -> IO ()
+-- printHash = print . hash
+
+main :: IO ()
+main = do
+  putStrLn "Hashing Foo1"
+  print . hash $ Foo1 22 'y' True
+  putStrLn "Hashing Foo2"
+  print . hash $ Foo2 "hello" ()
+  putStrLn "Hashing Bar"
+  print . hash $ Bar 55.50 9.125

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -122,6 +122,9 @@ benchmark benchmarks
   if impl(ghc) && flag(integer-gmp)
     Build-depends:   integer-gmp >= 0.2
 
+  if impl(ghc >= 7.2.1)
+    CPP-Options:     -DGENERICS
+
   include-dirs:
     benchmarks/cbits
 

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -39,6 +39,7 @@ Flag sse41
 
 Library
   Exposed-modules:   Data.Hashable
+                     Data.Hashable.Lifted
   Other-modules:     Data.Hashable.Class
   Build-depends:     base >= 4.0 && < 4.10,
                      bytestring >= 0.9 && < 0.11

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -37,6 +37,11 @@ Flag sse41
   Default: False
   Manual: True
 
+Flag examples
+  Description: Build example modules
+  Default: False
+  Manual: True
+
 Library
   Exposed-modules:   Data.Hashable
                      Data.Hashable.Lifted
@@ -147,6 +152,15 @@ benchmark benchmarks
     other-modules:     Data.Hashable.RandomSource
     if os(windows)
       extra-libraries: advapi32
+
+
+Executable hashable-examples
+  if flag(examples)
+    build-depends: base, hashable
+  else
+    buildable: False
+  hs-source-dirs: examples
+  main-is: Main.hs
 
 source-repository head
   type:     git

--- a/tests/Properties.hs
+++ b/tests/Properties.hs
@@ -9,7 +9,9 @@
 
 module Properties (properties) where
 
-import Data.Hashable (Hashable, hash, hashByteArray, hashPtr)
+import Data.Hashable (Hashable, hash, hashByteArray, hashPtr,
+         Hashed, hashed, unhashed, hashWithSalt)
+import Data.Hashable.Lifted (hashWithSalt1)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
@@ -208,6 +210,13 @@ pSum3_differ x = nub hs == hs
 
 #endif
 
+instance (Arbitrary a, Hashable a) => Arbitrary (Hashed a) where
+  arbitrary = fmap hashed arbitrary
+  shrink xs = map hashed $ shrink $ unhashed xs
+
+pLiftedHashed :: Int -> Hashed (Either Int String) -> Bool
+pLiftedHashed s h = hashWithSalt s h == hashWithSalt1 s h
+
 properties :: [Test]
 properties =
     [ testProperty "bernstein" pHash
@@ -239,6 +248,9 @@ properties =
       , testProperty "sum3_differ" pSum3_differ
       ]
 #endif
+    , testGroup "lifted law"
+      [ testProperty "Hashed" pLiftedHashed
+      ]
     ]
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
This implements what is proposed in https://github.com/tibbe/hashable/issues/114. It is not yet complete. I still need to add more instances. There are two deviations from the original proposal:

1. The method `liftHash` is not included. The reason for this are found in the documentation in `Data.Hashable.Lifted`.
2. The `Hashable2` class was included as well. This is mostly for consistency with other packages that provide higher rank typeclass variants.

In some of existing `Hashable` instances, I call `hashWithSalt1` to avoid duplicating code. You can look at the instance for `[]` to see this. I do not believe that this will hurt performance because the inliner should expand these.

The example instances I provide in `Data.Hashable.Lifted` have not been typechecked and are likely broken. I'll get to that soon.

Let me know at this point if there are any concerns so that the can be addressed before I write all the remaining instances.