### PR TITLE
Revert "Export Hashable1 and Hashable2"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,3 @@
-## Version 1.2.6.0
-
-  * Export `Hashable1` and `Hashable2`
-
 ## Version 1.2.5.0
 
   * Add `Hashable1` and `Hashable2`

--- a/Data/Hashable.hs
+++ b/Data/Hashable.hs
@@ -36,8 +36,7 @@ module Data.Hashable
 
       -- * Computing hash values
       Hashable(..)
-    , Hashable1(..)
-    , Hashable2(..)
+
       -- * Creating new instances
       -- | There are two ways to create new instances: by deriving
       -- instances automatically using GHC's generic programming
@@ -65,10 +64,6 @@ module Data.Hashable
     , hashByteArray
     , hashByteArrayWithSalt
 #endif
-      -- * Higher Rank Functions
-    , hashWithSalt1
-    , hashWithSalt2
-    , defaultLiftHashWithSalt
     -- * Caching hashes
     , Hashed
     , hashed

--- a/hashable.cabal
+++ b/hashable.cabal
@@ -1,5 +1,5 @@
 Name:                hashable
-Version:             1.2.6.0
+Version:             1.2.5.0
 Synopsis:            A class for types that can be converted to a hash value
 Description:         This package defines a class, 'Hashable', for types that
                      can be converted to a hash value.  This class


### PR DESCRIPTION
This reverts commit 2d00fec91b929189c82860941243f52bbe151e1a.

The classes are exported from `Data.Hashable.Lifted`, I'm not sure whether there's point to re-export them.