### PR TITLE
Bumped upper version bound for base

### DIFF
--- a/hashable.cabal
+++ b/hashable.cabal
@@ -46,7 +46,7 @@ Library
   Exposed-modules:   Data.Hashable
                      Data.Hashable.Lifted
   Other-modules:     Data.Hashable.Class
-  Build-depends:     base >= 4.4 && < 4.11,
+  Build-depends:     base >= 4.4 && < 4.12,
                      bytestring >= 0.9 && < 0.11,
                      deepseq >= 1.3
   if impl(ghc)


### PR DESCRIPTION
GHC 8.4.1-alpha1 was [announced](https://mail.haskell.org/pipermail/ghc-devs/2017-December/015235.html). While testing [Agda](https://github.com/agda/agda) with this version of GHC, I got the following error:

```
$ cabal install
Resolving dependencies...
cabal: Could not resolve dependencies:
trying: hashable-1.2.6.1 (user goal)
next goal: base (dependency of hashable-1.2.6.1)
rejecting: base-4.11.0.0/installed-4.1... (conflict: hashable => base>=4.4 &&
<4.11)
...
```

This PR fix the above issue.

Blocking https://github.com/agda/agda/issues/2878.  