### PR TITLE
Do not hash the second argument of Arg

### DIFF
--- a/Data/Hashable/Class.hs
+++ b/Data/Hashable/Class.hs
@@ -813,8 +813,8 @@ instance Hashable a => Hashable (Min a) where
 instance Hashable a => Hashable (Max a) where
     hashWithSalt p (Max a) = hashWithSalt p a
 
-instance (Hashable a, Hashable b) => Hashable (Arg a b) where
-    hashWithSalt p (Arg a b) = hashWithSalt p a `hashWithSalt` b
+instance Hashable a => Hashable (Arg a b) where
+    hashWithSalt p (Arg a _) = hashWithSalt p a
 
 instance Hashable a => Hashable (First a) where
     hashWithSalt p (First a) = hashWithSalt p a


### PR DESCRIPTION
The Eq instance for Arg ignores the second argument; therefore, the Hashable
instance must also ignore the second argument, lest two equal values have
different hashes.