### PR TITLE
Exclude any version of the xxHash folder from the language detection scan

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-xxHash-0.8.2/* linguist-detectable=false
+xxHash-*/* linguist-detectable=false


### PR DESCRIPTION
Since https://github.com/haskell-unordered-containers/hashable/pull/320 updated xxHash to 0.8.3, https://github.com/haskell-unordered-containers/hashable/pull/306 is no longer valid. This PR ensures that the xxHash folder, regardless of version, is excluded from the language-detection scan.