### PR TITLE
include/HsXXHash.h: Normalise byte order in withSeed_u{32,64}

### DIFF
--- a/include/HsXXHash.h
+++ b/include/HsXXHash.h
@@ -13,11 +13,28 @@ static inline uint64_t hs_XXH3_64bits_withSeed_offset(const uint8_t *ptr, size_t
 }
 
 static inline uint64_t hs_XXH3_64bits_withSeed_u64(uint64_t val, uint64_t seed) {
-    return XXH3_64bits_withSeed(&val, sizeof(val), seed);
+    unsigned int i;
+    uint8_t valAsArray[sizeof (val)];
+
+    for (i = 0; i < sizeof (val); ++i) {
+        valAsArray[i] = val & 0xFF;
+        val >>= 8;
+    }
+
+    return XXH3_64bits_withSeed(valAsArray, sizeof(val), seed);
 }
 
 static inline uint64_t hs_XXH3_64bits_withSeed_u32(uint32_t val, uint64_t seed) {
-    return XXH3_64bits_withSeed(&val, sizeof(val), seed);
+    unsigned int i;
+    uint8_t valAsArray[sizeof (val)];
+
+    for (i = 0; i < sizeof (val); ++i) {
+        valAsArray[i] = val & 0xFF;
+        val >>= 8;
+    }
+
+    return XXH3_64bits_withSeed(valAsArray, sizeof(val), seed);
+
 }
 
 static inline void hs_XXH3_64bits_update_offset(XXH3_state_t *statePtr, const uint8_t *ptr, size_t off, size_t len) {


### PR DESCRIPTION
Partial fix for #323

Current state:

```
Test suite xxhash-tests: RUNNING...
xxhash
  oneshot
    w64-ref:      FAIL
      *** Failed! Falsified (after 1 test and 1 shrink):
      1
      0
      3439722301264460078 /= 17540194650411207667
      Use --quickcheck-replay="(SMGen 7386192570663444294 1820595784376814299,0)" to reproduce.
      Use -p '/w64-ref/' to rerun this test only.
    w64-examples: OK
    w32-ref:      FAIL
      *** Failed! Falsified (after 1 test and 1 shrink):
      1
      0
      15781232456890734344 /= 982250997969081615
      Use --quickcheck-replay="(SMGen 4255009483900614667 6927204027265402359,0)" to reproduce.
      Use -p '/w32-ref/' to rerun this test only.
    w32-examples: OK
  incremental
    empty:        OK
      +++ OK, passed 100 tests.
    bs:           OK (0.01s)
      +++ OK, passed 100 tests.
```

Fails in the ref checks now because those still pass the bytes in host order.

https://github.com/haskell-unordered-containers/hashable/blob/92bd55d1f1251d4c5666216aa8cf84143778d5d3/tests/xxhash-tests.hs#L57-L63

I'll have to whack my head against a wall another time to figure out how to implement this normalisation on the Haskell side…

---

The calls to `XXH3_64bits_withSeed` are given `uint32_t*` / `uint64_t*` and the size of the corresponding type, while the expected argument is a `void*` pointing to an array and the size of the array. This means that the bytes that make up the `uint32_t` / `uint64_t` values are read in an order that depends on the host's endianness, and xxHash (which otherwise handles endianness-related differences consistently and guarantees same hashes) produces different hashes.

Instead, normalise the byte order by passing a pointer to an actual array, with the bytes that make up the input value in LE order.